### PR TITLE
Update GitHub Actions cache step version

### DIFF
--- a/.github/workflows/ci-konfetti.yaml
+++ b/.github/workflows/ci-konfetti.yaml
@@ -15,7 +15,7 @@ jobs:
 
       - uses: gradle/wrapper-validation-action@v1
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         with:
           path: |
             ~/.gradle/caches


### PR DESCRIPTION
V2 was deprecated and no longer downloading.